### PR TITLE
Disabling access from external network and fixing a bug due to which the web server did not turn off after closing the application

### DIFF
--- a/src/Lution/.streamlit/config.toml
+++ b/src/Lution/.streamlit/config.toml
@@ -10,3 +10,4 @@ toolbarMode = "minimal"
 headless = true
 [browser]
 gatherUsageStats = false
+serverAddress = "localhost"

--- a/src/Lution/.streamlit/config.toml
+++ b/src/Lution/.streamlit/config.toml
@@ -8,6 +8,7 @@ showSidebarNavigation = false
 toolbarMode = "minimal"
 [server]
 headless = true
+address = "localhost"
 [browser]
 gatherUsageStats = false
 serverAddress = "localhost"

--- a/src/Lution/launch.py
+++ b/src/Lution/launch.py
@@ -1,16 +1,12 @@
 import sys
 import subprocess
-import threading
 import time
 from PySide6.QtWidgets import QApplication
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtCore import QUrl
 
-def startweebserver():
-    subprocess.Popen(["streamlit", "run", "main.py"])
-
 def main():
-    threading.Thread(target=startweebserver, daemon=True).start()
+    weebserver = subprocess.Popen(["streamlit", "run", "main.py"])
     time.sleep(2)
 
     app = QApplication(sys.argv)
@@ -19,7 +15,13 @@ def main():
     browser.setWindowTitle("Lution - Windwon")
     browser.load(QUrl("http://localhost:8501"))
     browser.show()
-    sys.exit(app.exec())
+
+    exitCode=app.exec()
+
+    weebserver.terminate()
+    weebserver.wait()
+    
+    sys.exit(exitCode)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
At the moment, the application is available on open port 8502, while running, this can become a serious vulnerability!

I added a hardcoded localhost address to the config so that the server does not respond to requests from the external network
also, after closing the application, the streamlit web server did not close itself, which could cause a leak due to frequent opening and closing of the application

